### PR TITLE
call completeError on timeout

### DIFF
--- a/lib/managers/command_manager.dart
+++ b/lib/managers/command_manager.dart
@@ -137,7 +137,7 @@ class CommandManager with SdkAccessor {
     if (cmd.isAckRequired && reqId != null) {
       final timer = Timer(Duration(seconds: sdk.options.websocketTimeout), () {
         logger.e('sendCommand: did not receive ack in time');
-        throw AckTimeoutError();
+        _completers[reqId]?.completeError(AckTimeoutError());
       });
       _ackTimers[reqId] = timer;
 


### PR DESCRIPTION
Currently `CommandManager.sendCommand` throws `AckTimeoutError`. I expected the AckTimeoutError will be delivered as error of `OnUserMessageCallback` (`OnFileMessageCallback` or etc.) on bad network but i cannot catch the error. So I suggest that deliver error using `completeError` instead throw.