### PR TITLE
Fix token type during unregister push token

### DIFF
--- a/lib/request/user/push/push_unregister_request.dart
+++ b/lib/request/user/push/push_unregister_request.dart
@@ -12,7 +12,16 @@ class UserPushTokenUnregisterRequest extends ApiRequest {
     required String token,
     String? userId,
   }) : super(userId: userId) {
-    final typeString = type == PushTokenType.fcm ? 'gcm' : type.asString();
+    var typeString = '';
+    
+    if (type == PushTokenType.fcm) {
+      typeString = 'gcm';
+    } else if (type == PushTokenType.hms) {
+      typeString = 'huawei';
+    } else {
+      typeString = type.asString();
+    }
+
     url = 'users/${userId ?? state.userId}/push/$typeString/$token';
   }
 }


### PR DESCRIPTION
### Description
Getting `BadRequestError` when unregistering push token for Huawei device. Turn out that token type sent is wrong. 
Expected: huawei type send as `huawei`
Actual: huawei type send as `hms`

Reference:
https://sendbird.com/docs/chat/v3/platform-api/user/managing-device-tokens/remove-a-registration-or-device-token-from-an-owner