### PR TITLE
Update connectivity_plus to 4.0.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   http: ^0.13.6
   logger: ^1.4.0
   mime: ^1.0.4
-  connectivity_plus: ^2.3.9
+  connectivity_plus: ^4.0.1
   http_parser: ^4.0.2
   web_socket_channel: ^2.4.0
   universal_io: ^2.2.0


### PR DESCRIPTION
After a `flutter pub get` I get this error because I use `connectivity_plus` too:

```
Resolving dependencies...
Because sendbird_chat_sdk >=4.0.2 depends on connectivity_plus ^2.3.9 and pianity_flutter depends on connectivity_plus ^4.0.1, sendbird_chat_sdk >=4.0.2 is forbidden.
So, because pianity_flutter depends on sendbird_chat_sdk ^4.0.2, version solving failed.
```
This PR update the version of `connectivity_plus` to `4.0.1`.