### PR TITLE
fix : convert ScheduledStatus enum to string values

### DIFF
--- a/lib/src/internal/network/http/http_client/request/channel/group_channel/scheduled_message/group_channel_scheduled_message_get_list_request.dart
+++ b/lib/src/internal/network/http/http_client/request/channel/group_channel/scheduled_message/group_channel_scheduled_message_get_list_request.dart
@@ -22,6 +22,15 @@ class GroupChannelScheduledMessageListGetRequest extends ApiRequest {
     MessageTypeFilter.user: 'MESG',
   };
 
+  final scheduledStatusEnumMap = <ScheduledStatus, String>{
+    ScheduledStatus.pending: 'pending',
+    ScheduledStatus.inQueue: 'in_queue',
+    ScheduledStatus.sent: 'sent',
+    ScheduledStatus.failed: 'failed',
+    ScheduledStatus.canceled: 'canceled',
+    ScheduledStatus.removed: 'removed',
+  };
+
   GroupChannelScheduledMessageListGetRequest(
     Chat chat, {
     String? channelUrl,
@@ -44,7 +53,7 @@ class GroupChannelScheduledMessageListGetRequest extends ApiRequest {
       'token': token,
       'limit': limit,
       'reverse': reverse,
-      'status': status,
+      'status': status?.map((e) => scheduledStatusEnumMap[e]).toList(),
       'message_type': messageTypeFilterEnumMap[messageType],
       'order': scheduledMessageListOrderEnumMap[order],
     };


### PR DESCRIPTION
- Convert ScheduledStatus enum to string when processing status parameter in GroupChannelScheduledMessageListGetRequest
- Convert Enum values ​​to strings such as 'pending', 'in_queue' required by API using scheduledStatusEnumMap
- Resolve "RequestFailedException(800220): Converting object to an encodable object failed" error