### PR TITLE
feat: migrate to isar_community package  #144

### DIFF
--- a/lib/src/internal/db/db.dart
+++ b/lib/src/internal/db/db.dart
@@ -1,6 +1,6 @@
 // Copyright (c) 2023 Sendbird, Inc. All rights reserved.
 
-import 'package:isar/isar.dart';
+import 'package:isar_community/isar.dart';
 import 'package:sendbird_chat_sdk/src/internal/db/schema/channel/c_feed_channel.dart';
 import 'package:sendbird_chat_sdk/src/internal/db/schema/channel/c_group_channel.dart';
 import 'package:sendbird_chat_sdk/src/internal/db/schema/channel/meta/c_channel_info.dart';

--- a/lib/src/internal/db/schema/channel/c_base_channel.dart
+++ b/lib/src/internal/db/schema/channel/c_base_channel.dart
@@ -2,7 +2,7 @@
 
 import 'dart:convert';
 
-import 'package:isar/isar.dart';
+import 'package:isar_community/isar.dart';
 import 'package:sendbird_chat_sdk/src/internal/main/chat/chat.dart';
 import 'package:sendbird_chat_sdk/src/public/core/channel/base_channel/base_channel.dart';
 import 'package:sendbird_chat_sdk/src/public/core/channel/feed_channel/feed_channel.dart';

--- a/lib/src/internal/db/schema/channel/c_feed_channel.dart
+++ b/lib/src/internal/db/schema/channel/c_feed_channel.dart
@@ -1,6 +1,6 @@
 // Copyright (c) 2023 Sendbird, Inc. All rights reserved.
 
-import 'package:isar/isar.dart';
+import 'package:isar_community/isar.dart';
 import 'package:sendbird_chat_sdk/sendbird_chat_sdk.dart';
 import 'package:sendbird_chat_sdk/src/internal/db/schema/channel/c_base_channel.dart';
 import 'package:sendbird_chat_sdk/src/internal/db/schema/channel/c_group_channel.dart';

--- a/lib/src/internal/db/schema/channel/c_group_channel.dart
+++ b/lib/src/internal/db/schema/channel/c_group_channel.dart
@@ -2,7 +2,7 @@
 
 import 'dart:convert';
 
-import 'package:isar/isar.dart';
+import 'package:isar_community/isar.dart';
 import 'package:sendbird_chat_sdk/sendbird_chat_sdk.dart';
 import 'package:sendbird_chat_sdk/src/internal/db/schema/channel/c_base_channel.dart';
 import 'package:sendbird_chat_sdk/src/internal/db/schema/message/c_base_message.dart';

--- a/lib/src/internal/db/schema/channel/meta/c_channel_info.dart
+++ b/lib/src/internal/db/schema/channel/meta/c_channel_info.dart
@@ -1,6 +1,6 @@
 // Copyright (c) 2023 Sendbird, Inc. All rights reserved.
 
-import 'package:isar/isar.dart';
+import 'package:isar_community/isar.dart';
 import 'package:sendbird_chat_sdk/src/internal/db/schema/channel/meta/channel_info.dart';
 import 'package:sendbird_chat_sdk/src/internal/main/chat/chat.dart';
 

--- a/lib/src/internal/db/schema/chunk/c_base_chunk.dart
+++ b/lib/src/internal/db/schema/chunk/c_base_chunk.dart
@@ -1,6 +1,6 @@
 // Copyright (c) 2023 Sendbird, Inc. All rights reserved.
 
-import 'package:isar/isar.dart';
+import 'package:isar_community/isar.dart';
 import 'package:sendbird_chat_sdk/src/internal/db/schema/chunk/base_chunk.dart';
 import 'package:sendbird_chat_sdk/src/internal/db/schema/chunk/chunk.dart';
 import 'package:sendbird_chat_sdk/src/internal/main/chat/chat.dart';

--- a/lib/src/internal/db/schema/chunk/c_channel_chunk.dart
+++ b/lib/src/internal/db/schema/chunk/c_channel_chunk.dart
@@ -1,6 +1,6 @@
 // Copyright (c) 2023 Sendbird, Inc. All rights reserved.
 
-import 'package:isar/isar.dart';
+import 'package:isar_community/isar.dart';
 import 'package:sendbird_chat_sdk/src/internal/db/schema/chunk/c_base_chunk.dart';
 import 'package:sendbird_chat_sdk/src/internal/db/schema/chunk/channel_chunk.dart';
 import 'package:sendbird_chat_sdk/src/internal/main/chat/chat.dart';

--- a/lib/src/internal/db/schema/chunk/c_message_chunk.dart
+++ b/lib/src/internal/db/schema/chunk/c_message_chunk.dart
@@ -1,6 +1,6 @@
 // Copyright (c) 2023 Sendbird, Inc. All rights reserved.
 
-import 'package:isar/isar.dart';
+import 'package:isar_community/isar.dart';
 import 'package:sendbird_chat_sdk/src/internal/db/schema/chunk/c_base_chunk.dart';
 import 'package:sendbird_chat_sdk/src/internal/db/schema/chunk/message_chunk.dart';
 import 'package:sendbird_chat_sdk/src/internal/main/chat/chat.dart';

--- a/lib/src/internal/db/schema/login/c_login.dart
+++ b/lib/src/internal/db/schema/login/c_login.dart
@@ -2,7 +2,7 @@
 
 import 'dart:convert';
 
-import 'package:isar/isar.dart';
+import 'package:isar_community/isar.dart';
 import 'package:sendbird_chat_sdk/src/internal/db/schema/login/login.dart';
 import 'package:sendbird_chat_sdk/src/internal/main/chat/chat.dart';
 import 'package:sendbird_chat_sdk/src/internal/main/chat_context/chat_context.dart';

--- a/lib/src/internal/db/schema/message/c_admin_message.dart
+++ b/lib/src/internal/db/schema/message/c_admin_message.dart
@@ -1,6 +1,6 @@
 // Copyright (c) 2023 Sendbird, Inc. All rights reserved.
 
-import 'package:isar/isar.dart';
+import 'package:isar_community/isar.dart';
 import 'package:sendbird_chat_sdk/src/internal/db/schema/message/c_base_message.dart';
 import 'package:sendbird_chat_sdk/src/internal/db/schema/message/c_root_message.dart';
 import 'package:sendbird_chat_sdk/src/internal/db/schema/message/meta/c_channel_message.dart';

--- a/lib/src/internal/db/schema/message/c_base_message.dart
+++ b/lib/src/internal/db/schema/message/c_base_message.dart
@@ -2,7 +2,7 @@
 
 import 'dart:convert';
 
-import 'package:isar/isar.dart';
+import 'package:isar_community/isar.dart';
 import 'package:sendbird_chat_sdk/src/internal/db/schema/message/c_admin_message.dart';
 import 'package:sendbird_chat_sdk/src/internal/db/schema/message/c_file_message.dart';
 import 'package:sendbird_chat_sdk/src/internal/db/schema/message/c_root_message.dart';

--- a/lib/src/internal/db/schema/message/c_file_message.dart
+++ b/lib/src/internal/db/schema/message/c_file_message.dart
@@ -3,7 +3,7 @@
 import 'dart:io';
 import 'dart:ui';
 
-import 'package:isar/isar.dart';
+import 'package:isar_community/isar.dart';
 import 'package:sendbird_chat_sdk/src/internal/db/schema/message/c_base_message.dart';
 import 'package:sendbird_chat_sdk/src/internal/db/schema/message/c_root_message.dart';
 import 'package:sendbird_chat_sdk/src/internal/db/schema/message/meta/c_channel_message.dart';

--- a/lib/src/internal/db/schema/message/c_notification_message.dart
+++ b/lib/src/internal/db/schema/message/c_notification_message.dart
@@ -2,7 +2,7 @@
 
 import 'dart:convert';
 
-import 'package:isar/isar.dart';
+import 'package:isar_community/isar.dart';
 import 'package:sendbird_chat_sdk/src/internal/db/schema/message/c_root_message.dart';
 import 'package:sendbird_chat_sdk/src/internal/db/schema/message/meta/c_channel_message.dart';
 import 'package:sendbird_chat_sdk/src/internal/main/chat/chat.dart';

--- a/lib/src/internal/db/schema/message/c_root_message.dart
+++ b/lib/src/internal/db/schema/message/c_root_message.dart
@@ -2,7 +2,7 @@
 
 import 'dart:convert';
 
-import 'package:isar/isar.dart';
+import 'package:isar_community/isar.dart';
 import 'package:sendbird_chat_sdk/src/internal/db/schema/user/c_user.dart';
 import 'package:sendbird_chat_sdk/src/internal/main/chat/chat.dart';
 import 'package:sendbird_chat_sdk/src/public/core/message/root_message.dart';

--- a/lib/src/internal/db/schema/message/c_user_message.dart
+++ b/lib/src/internal/db/schema/message/c_user_message.dart
@@ -2,7 +2,7 @@
 
 import 'dart:convert';
 
-import 'package:isar/isar.dart';
+import 'package:isar_community/isar.dart';
 import 'package:sendbird_chat_sdk/src/internal/db/schema/message/c_base_message.dart';
 import 'package:sendbird_chat_sdk/src/internal/db/schema/message/c_root_message.dart';
 import 'package:sendbird_chat_sdk/src/internal/db/schema/message/meta/c_channel_message.dart';

--- a/lib/src/internal/db/schema/message/meta/c_channel_access.dart
+++ b/lib/src/internal/db/schema/message/meta/c_channel_access.dart
@@ -1,6 +1,6 @@
 // Copyright (c) 2023 Sendbird, Inc. All rights reserved.
 
-import 'package:isar/isar.dart';
+import 'package:isar_community/isar.dart';
 import 'package:sendbird_chat_sdk/src/internal/db/schema/message/meta/channel_access.dart';
 import 'package:sendbird_chat_sdk/src/internal/main/chat/chat.dart';
 

--- a/lib/src/internal/db/schema/message/meta/c_channel_message.dart
+++ b/lib/src/internal/db/schema/message/meta/c_channel_message.dart
@@ -1,6 +1,6 @@
 // Copyright (c) 2023 Sendbird, Inc. All rights reserved.
 
-import 'package:isar/isar.dart';
+import 'package:isar_community/isar.dart';
 import 'package:sendbird_chat_sdk/sendbird_chat_sdk.dart';
 import 'package:sendbird_chat_sdk/src/internal/db/schema/message/c_admin_message.dart';
 import 'package:sendbird_chat_sdk/src/internal/db/schema/message/c_file_message.dart';

--- a/lib/src/internal/db/schema/message/meta/c_message_changelog_info.dart
+++ b/lib/src/internal/db/schema/message/meta/c_message_changelog_info.dart
@@ -1,6 +1,6 @@
 // Copyright (c) 2023 Sendbird, Inc. All rights reserved.
 
-import 'package:isar/isar.dart';
+import 'package:isar_community/isar.dart';
 import 'package:sendbird_chat_sdk/src/internal/db/schema/message/meta/message_changelog_info.dart';
 import 'package:sendbird_chat_sdk/src/internal/main/chat/chat.dart';
 

--- a/lib/src/internal/db/schema/user/c_member.dart
+++ b/lib/src/internal/db/schema/user/c_member.dart
@@ -1,6 +1,6 @@
 // Copyright (c) 2023 Sendbird, Inc. All rights reserved.
 
-import 'package:isar/isar.dart';
+import 'package:isar_community/isar.dart';
 import 'package:sendbird_chat_sdk/src/internal/db/schema/user/c_user.dart';
 import 'package:sendbird_chat_sdk/src/internal/main/chat/chat.dart';
 import 'package:sendbird_chat_sdk/src/public/core/user/member.dart';

--- a/lib/src/internal/db/schema/user/c_sender.dart
+++ b/lib/src/internal/db/schema/user/c_sender.dart
@@ -1,6 +1,6 @@
 // Copyright (c) 2023 Sendbird, Inc. All rights reserved.
 
-import 'package:isar/isar.dart';
+import 'package:isar_community/isar.dart';
 import 'package:sendbird_chat_sdk/src/internal/db/schema/user/c_user.dart';
 import 'package:sendbird_chat_sdk/src/internal/main/chat/chat.dart';
 import 'package:sendbird_chat_sdk/src/public/core/user/sender.dart';

--- a/lib/src/internal/db/schema/user/c_user.dart
+++ b/lib/src/internal/db/schema/user/c_user.dart
@@ -2,7 +2,7 @@
 
 import 'dart:convert';
 
-import 'package:isar/isar.dart';
+import 'package:isar_community/isar.dart';
 import 'package:sendbird_chat_sdk/src/internal/main/chat/chat.dart';
 import 'package:sendbird_chat_sdk/src/public/core/user/user.dart';
 import 'package:sendbird_chat_sdk/src/public/main/define/enums.dart';

--- a/lib/src/internal/main/chat_manager/db_manager.dart
+++ b/lib/src/internal/main/chat_manager/db_manager.dart
@@ -1,7 +1,7 @@
 // Copyright (c) 2023 Sendbird, Inc. All rights reserved.
 
 import 'package:flutter/foundation.dart';
-import 'package:isar/isar.dart';
+import 'package:isar_community/isar.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:sendbird_chat_sdk/sendbird_chat_sdk.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,8 +30,8 @@ dependencies:
   web_socket_channel: '>=2.4.0 <4.0.0'
   universal_io: ^2.2.0
   async: ^2.10.0
-  isar: ^3.1.0+1
-  isar_flutter_libs: ^3.1.0+1
+  isar_community: ^3.1.0+1
+  isar_community_flutter_libs: ^3.1.0+1
   path_provider: ^2.1.1
   path: ^1.8.2
 
@@ -43,4 +43,4 @@ dev_dependencies:
   stack_trace: ^1.11.0
   json_serializable: ^6.6.2
   build_runner: ^2.3.3
-  isar_generator: ^3.1.0+1
+  isar_community_generator: ^3.1.0+1


### PR DESCRIPTION
This pull request migrates from the original isar package to the isar_community package because isar is no longer maintained. The main goal is to resolve the Support 16kb page size issue ([issue #144](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)), as the community package provides ongoing support and necessary fixes. No functional changes were made—only dependency and import updates.

Before (with isar, issue present)
<img width="1920" height="1020" alt="483848854-fab9b38d-050e-4b70-954f-6952dacc8c60" src="https://github.com/user-attachments/assets/51f3668d-4a96-4574-858a-e10e1f9abd8a" />

After (with isar_community, issue resolved)
<img width="1098" height="525" alt="Captura de Tela 2025-09-11 às 11 42 37" src="https://github.com/user-attachments/assets/06444784-1c36-4a79-9cdd-fd6367bfb600" />
